### PR TITLE
Add mock for `on` event function

### DIFF
--- a/src/Gpio.js
+++ b/src/Gpio.js
@@ -129,6 +129,10 @@ class Gpio {
 		log(`[GPIO ${this.gpio} / getServoPulseWidth] Getting pulseWidth = ${this.servoPulseWidth}`);
 		return this.servoPulseWidth;
 	}
+
+	on(event, handler) {
+		log(`[GPIO ${this.gpio} / on ${event}] will run handler`);
+	}
 }
 
 Gpio.INPUT = 0; // PI_INPUT

--- a/test/gpioTest.js
+++ b/test/gpioTest.js
@@ -72,4 +72,9 @@ describe("Gpio", function() {
 		pin.servoWrite(3000);
 		assert.equal(pin.getServoPulseWidth(), 2500);
 	});
+
+	it("should be able to call on", function() {
+		const pin = new Gpio(13);
+		assert.equal(typeof pin.on, 'function');
+	});
 });

--- a/test/gpioTest.js
+++ b/test/gpioTest.js
@@ -75,6 +75,6 @@ describe("Gpio", function() {
 
 	it("should be able to call on", function() {
 		const pin = new Gpio(13);
-		assert.equal(typeof pin.on, 'function');
+		pin.on('event', () => {});
 	});
 });


### PR DESCRIPTION
This wonderful package is sorely missing one critical mock implementation. Here it is.